### PR TITLE
Add test for Verifreg actor

### DIFF
--- a/testing/verifreg/src/main.rs
+++ b/testing/verifreg/src/main.rs
@@ -92,7 +92,7 @@ fn main() {
         allowance: verifier_allowance,
     };
 
-    println!("Register contract-actor as verifier");
+    println!("Registering contract-actor as verifier");
     // by this call we register our contract actor as a verifier
     let message = Message {
         from: sender.1,
@@ -108,8 +108,8 @@ fn main() {
         .execute_message(message, ApplyKind::Explicit, 100)
         .unwrap();
 
-    dbg!("add_verified_client {:?}", &res);
-    assert_eq!(res.msg_receipt.exit_code.value(), 0);
+    dbg!("Registering actor result {:?}", &res);
+    assert_eq!(res.msg_receipt.exit_code.value(), 18);
 
     println!("Calling `add_verified_client`");
     let message = Message {

--- a/testing/verifreg/src/main.rs
+++ b/testing/verifreg/src/main.rs
@@ -1,21 +1,22 @@
-use fvm_integration_tests::tester::{Account, Tester};
-use fvm_integration_tests::dummy::DummyExterns;
 use fvm_integration_tests::bundle;
+use fvm_integration_tests::dummy::DummyExterns;
+use fvm_integration_tests::tester::{Account, Tester};
 use fvm_ipld_encoding::{strict_bytes, tuple::*};
+use fvm_shared::bigint::{bigint_ser, BigInt};
+
+use fil_actor_eam::Return;
+use fil_actors_runtime::{EAM_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR};
+use fvm::executor::{ApplyKind, Executor};
+use fvm_ipld_blockstore::MemoryBlockstore;
+use fvm_ipld_encoding::RawBytes;
+use fvm_shared::address::Address;
+use fvm_shared::message::Message;
+use fvm_shared::sector::StoragePower;
 use fvm_shared::state::StateTreeVersion;
 use fvm_shared::version::NetworkVersion;
-use fvm_ipld_blockstore::MemoryBlockstore;
 use std::env;
-use fvm_shared::message::Message;
-use fvm::executor::{ApplyKind, Executor};
-use fil_actor_eam::Return;
-use fvm_ipld_encoding::RawBytes;
-use fil_actors_runtime::{EAM_ACTOR_ADDR};
-use fvm_shared::address::Address;
 
-
-const WASM_COMPILED_PATH: &str =
-   "../../build/v0.8/tests/VerifRegApiTest.bin";
+const WASM_COMPILED_PATH: &str = "../../build/v0.8/tests/VerifRegApiTest.bin";
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct Create2Params {
@@ -25,17 +26,26 @@ pub struct Create2Params {
     pub salt: [u8; 32],
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+pub struct VerifierParams {
+    pub address: Address,
+    #[serde(with = "bigint_ser")]
+    pub allowance: StoragePower,
+}
+
 fn main() {
     println!("Testing solidity API");
 
     let bs = MemoryBlockstore::default();
-    let actors = std::fs::read("../builtin-actors/output/builtin-actors-devnet-wasm.car").expect("Unable to read actor devnet file file");
+    let actors = std::fs::read("../builtin-actors/output/builtin-actors-devnet-wasm.car")
+        .expect("Unable to read actor devnet file file");
     let bundle_root = bundle::import_bundle(&bs, &actors).unwrap();
 
     let mut tester =
         Tester::new(NetworkVersion::V18, StateTreeVersion::V5, bundle_root, bs).unwrap();
 
-    let sender: [Account; 1] = tester.create_accounts().unwrap();
+    let accounts: [Account; 2] = tester.create_accounts().unwrap();
+    let (sender, verified_client) = (accounts[0], accounts[1]);
 
     // Instantiate machine
     tester.instantiate_machine(DummyExterns).unwrap();
@@ -58,31 +68,39 @@ fn main() {
     };
 
     let message = Message {
-        from: sender[0].1,
+        from: sender.1,
         to: EAM_ACTOR_ADDR,
         gas_limit: 1000000000,
         method_num: 3,
+        sequence: 0,
         params: RawBytes::serialize(constructor_params).unwrap(),
         ..Message::default()
     };
 
     let res = executor
         .execute_message(message, ApplyKind::Explicit, 100)
-        .unwrap();
+        .unwrap(); //use fil_actors
 
     assert_eq!(res.msg_receipt.exit_code.value(), 0);
 
-    let exec_return : Return = RawBytes::deserialize(&res.msg_receipt.return_data).unwrap();
+    let exec_return: Return = RawBytes::deserialize(&res.msg_receipt.return_data).unwrap();
+    let contract_actor = exec_return.actor_id;
 
-    println!("Calling `add_verified_client`");
+    let verifier_allowance = fvm_shared::sector::StoragePower::from(2 * 1048576u64);
+    let params = VerifierParams {
+        address: Address::new_id(contract_actor),
+        allowance: verifier_allowance,
+    };
 
+    println!("Register contract-actor as verifier");
+    // by this call we register our contract actor as a verifier
     let message = Message {
-        from: sender[0].1,
-        to: Address::new_id(exec_return.actor_id),
+        from: sender.1,
+        to: VERIFIED_REGISTRY_ACTOR_ADDR,
         gas_limit: 1000000000,
         method_num: 2,
         sequence: 1,
-        params: RawBytes::new(hex::decode("58E4557074610000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000002006400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000030010000000000000000000000000000000000000000000000000000000000000").unwrap()),
+        params: RawBytes::serialize(params).unwrap(),
         ..Message::default()
     };
 
@@ -90,6 +108,116 @@ fn main() {
         .execute_message(message, ApplyKind::Explicit, 100)
         .unwrap();
 
-    // FIXME: "caller f0101 is not a verifier"
+    dbg!("add_verified_client {:?}", &res);
+    assert_eq!(res.msg_receipt.exit_code.value(), 0);
+
+    println!("Calling `add_verified_client`");
+    let message = Message {
+        from: sender.1,
+        to: Address::new_id(exec_return.actor_id),
+        gas_limit: 1000000000,
+        method_num: 2,
+        sequence: 2,
+        params: RawBytes::new(hex::decode("58E455707461000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000001501DCE5B7F69E73494891556A350F8CC357614916D5000000000000000000000000000000000000000000000000000000000000000000000000000000000000060044002000000000000000000000000000000000000000000000000000000000").unwrap()),
+        ..Message::default()
+    };
+
+    let res = executor
+        .execute_message(message, ApplyKind::Explicit, 100)
+        .unwrap();
+
+    println!("add_verified_client {:?}", &res);
+    assert_eq!(res.msg_receipt.exit_code.value(), 0);
+
+    println!("Calling `get_claims`");
+
+    let message = Message {
+        from: sender.1,
+        to: Address::new_id(exec_return.actor_id),
+        gas_limit: 1000000000,
+        method_num: 2,
+        sequence: 3,
+        //  get_claims params [201, [0,1]]
+        params: RawBytes::new(hex::decode("58C4DBCB98AB000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000C90000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001").unwrap()),
+        ..Message::default()
+    };
+
+    let res = executor
+        .execute_message(message, ApplyKind::Explicit, 100)
+        .unwrap();
+
+    // Should not fail as actor would return an empty list of claims
+    assert_eq!(res.msg_receipt.exit_code.value(), 0);
+
+    println!("Calling `extend_claim_term`");
+    let message = Message {
+        from: sender.1,
+        to: Address::new_id(exec_return.actor_id),
+        gas_limit: 1000000000,
+        method_num: 2,
+        sequence: 4,
+        params: RawBytes::new(hex::decode("58C4D8308B8C000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000660000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001").unwrap()),
+        ..Message::default()
+    };
+
+    let res = executor
+        .execute_message(message, ApplyKind::Explicit, 100)
+        .unwrap();
+
+    //dbg!("extend_claim_term result {:?}", &res);
+    assert_eq!(res.msg_receipt.exit_code.value(), 0);
+
+    println!("Calling `remove_expired_allocations`");
+
+    let message = Message {
+        from: sender.1,
+        to: Address::new_id(exec_return.actor_id),
+        gas_limit: 1000000000,
+        method_num: 2,
+        sequence: 5,
+        //  remove_expired_allocations params [actorId(101), []] empty list which means remove all
+        params: RawBytes::new(hex::decode("5884DF5527250000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000006500000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000").unwrap()),
+        ..Message::default()
+    };
+
+    let res = executor
+        .execute_message(message, ApplyKind::Explicit, 100)
+        .unwrap();
+
+    assert_eq!(res.msg_receipt.exit_code.value(), 33);
+
+    println!("Calling `remove_expired_claims`");
+    let message = Message {
+        from: sender.1,
+        to: Address::new_id(exec_return.actor_id),
+        gas_limit: 1000000000,
+        method_num: 2,
+        sequence: 6,
+        params: RawBytes::new(hex::decode("58C4D8308B8C000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000660000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001").unwrap()),
+        ..Message::default()
+    };
+
+    let res = executor
+        .execute_message(message, ApplyKind::Explicit, 100)
+        .unwrap();
+
+    //dbg!("claims result {:?}", &res);
+    assert_eq!(res.msg_receipt.exit_code.value(), 33);
+
+    println!("Calling `universal_receiver_hook`");
+    let message = Message {
+        from: sender.1,
+        to: Address::new_id(exec_return.actor_id),
+        gas_limit: 1000000000,
+        method_num: 2,
+        sequence: 7,
+        params: RawBytes::new(hex::decode("58A4AA7E0F7B000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000C9000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000031245AB0000000000000000000000000000000000000000000000000000000000").unwrap()),
+        ..Message::default()
+    };
+
+    let res = executor
+        .execute_message(message, ApplyKind::Explicit, 100)
+        .unwrap();
+
     assert_eq!(res.msg_receipt.exit_code.value(), 33);
 }

--- a/testing/verifreg/src/main.rs
+++ b/testing/verifreg/src/main.rs
@@ -46,6 +46,9 @@ fn main() {
 
     let accounts: [Account; 2] = tester.create_accounts().unwrap();
     let (sender, verified_client) = (accounts[0], accounts[1]);
+    // As the governor address for verifreg is 199, we create many many addresses in order to initialize the ID 199 with some tokens
+    // and make it a valid address to use.
+    let accounts: [Account; 200] = tester.create_accounts().unwrap();
 
     // Instantiate machine
     tester.instantiate_machine(DummyExterns).unwrap();
@@ -86,7 +89,7 @@ fn main() {
     let exec_return: Return = RawBytes::deserialize(&res.msg_receipt.return_data).unwrap();
     let contract_actor = exec_return.actor_id;
 
-    let verifier_allowance = fvm_shared::sector::StoragePower::from(2 * 1048576u64);
+    let verifier_allowance = fvm_shared::sector::StoragePower::from(2 * 1024u64);
     let params = VerifierParams {
         address: Address::new_id(contract_actor),
         allowance: verifier_allowance,
@@ -95,11 +98,12 @@ fn main() {
     println!("Registering contract-actor as verifier");
     // by this call we register our contract actor as a verifier
     let message = Message {
-        from: sender.1,
+        //from: sender.1,
+        from: Address::new_id(199),
         to: VERIFIED_REGISTRY_ACTOR_ADDR,
         gas_limit: 1000000000,
         method_num: 2,
-        sequence: 1,
+        sequence: 0,
         params: RawBytes::serialize(params).unwrap(),
         ..Message::default()
     };
@@ -108,8 +112,8 @@ fn main() {
         .execute_message(message, ApplyKind::Explicit, 100)
         .unwrap();
 
-    dbg!("Registering actor result {:?}", &res);
-    assert_eq!(res.msg_receipt.exit_code.value(), 18);
+    //println!("Registering actor result {:?}", &res);
+    assert_eq!(res.msg_receipt.exit_code.value(), 0);
 
     println!("Calling `add_verified_client`");
     let message = Message {
@@ -117,7 +121,7 @@ fn main() {
         to: Address::new_id(exec_return.actor_id),
         gas_limit: 1000000000,
         method_num: 2,
-        sequence: 2,
+        sequence: 1,
         params: RawBytes::new(hex::decode("58E455707461000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000001501DCE5B7F69E73494891556A350F8CC357614916D5000000000000000000000000000000000000000000000000000000000000000000000000000000000000060044002000000000000000000000000000000000000000000000000000000000").unwrap()),
         ..Message::default()
     };
@@ -136,7 +140,7 @@ fn main() {
         to: Address::new_id(exec_return.actor_id),
         gas_limit: 1000000000,
         method_num: 2,
-        sequence: 3,
+        sequence: 2,
         //  get_claims params [201, [0,1]]
         params: RawBytes::new(hex::decode("58C4DBCB98AB000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000C90000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001").unwrap()),
         ..Message::default()
@@ -155,7 +159,7 @@ fn main() {
         to: Address::new_id(exec_return.actor_id),
         gas_limit: 1000000000,
         method_num: 2,
-        sequence: 4,
+        sequence: 3,
         params: RawBytes::new(hex::decode("58C4D8308B8C000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000660000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001").unwrap()),
         ..Message::default()
     };
@@ -174,7 +178,7 @@ fn main() {
         to: Address::new_id(exec_return.actor_id),
         gas_limit: 1000000000,
         method_num: 2,
-        sequence: 5,
+        sequence: 4,
         //  remove_expired_allocations params [actorId(101), []] empty list which means remove all
         params: RawBytes::new(hex::decode("5884DF5527250000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000006500000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000").unwrap()),
         ..Message::default()
@@ -192,7 +196,7 @@ fn main() {
         to: Address::new_id(exec_return.actor_id),
         gas_limit: 1000000000,
         method_num: 2,
-        sequence: 6,
+        sequence: 5,
         params: RawBytes::new(hex::decode("58C4D8308B8C000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000660000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001").unwrap()),
         ..Message::default()
     };
@@ -210,7 +214,7 @@ fn main() {
         to: Address::new_id(exec_return.actor_id),
         gas_limit: 1000000000,
         method_num: 2,
-        sequence: 7,
+        sequence: 6,
         params: RawBytes::new(hex::decode("58A4AA7E0F7B000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000C9000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000031245AB0000000000000000000000000000000000000000000000000000000000").unwrap()),
         ..Message::default()
     };

--- a/testing/verifreg/src/main.rs
+++ b/testing/verifreg/src/main.rs
@@ -46,9 +46,9 @@ fn main() {
 
     let accounts: [Account; 2] = tester.create_accounts().unwrap();
     let (sender, verified_client) = (accounts[0], accounts[1]);
-    // As the governor address for verifreg is 199, we create many many addresses in order to initialize the ID 199 with some tokens
-    // and make it a valid address to use.
-    let accounts: [Account; 200] = tester.create_accounts().unwrap();
+    // register address so we can use senderID 199 which is the governor address of the verifreg
+    // actor
+    let _accounts: [Account; 200] = tester.create_accounts().unwrap();
 
     // Instantiate machine
     tester.instantiate_machine(DummyExterns).unwrap();
@@ -112,7 +112,6 @@ fn main() {
         .execute_message(message, ApplyKind::Explicit, 100)
         .unwrap();
 
-    //println!("Registering actor result {:?}", &res);
     assert_eq!(res.msg_receipt.exit_code.value(), 0);
 
     println!("Calling `add_verified_client`");
@@ -168,7 +167,6 @@ fn main() {
         .execute_message(message, ApplyKind::Explicit, 100)
         .unwrap();
 
-    //dbg!("extend_claim_term result {:?}", &res);
     assert_eq!(res.msg_receipt.exit_code.value(), 0);
 
     println!("Calling `remove_expired_allocations`");
@@ -205,7 +203,6 @@ fn main() {
         .execute_message(message, ApplyKind::Explicit, 100)
         .unwrap();
 
-    //dbg!("claims result {:?}", &res);
     assert_eq!(res.msg_receipt.exit_code.value(), 33);
 
     println!("Calling `universal_receiver_hook`");


### PR DESCRIPTION
This adds tests for the methods defined in the VerifReg contract. 
The current test initializes the contract actor and registers it as a verifier using the governor address and calling the VERIFREG_ACTOR directly.
