### PR TITLE
Rename BigNumber to BigInt

### DIFF
--- a/contracts/v0.8/DataCapAPI.sol
+++ b/contracts/v0.8/DataCapAPI.sol
@@ -21,7 +21,7 @@ pragma solidity >=0.4.25 <=0.8.17;
 
 import "./types/DataCapTypes.sol";
 import "./cbor/DataCapCbor.sol";
-import "./cbor/BigNumberCbor.sol";
+import "./cbor/BigIntCbor.sol";
 
 import "./utils/Actor.sol";
 
@@ -62,7 +62,7 @@ library DataCapAPI {
         return result.deserializeString();
     }
 
-    function totalSupply() internal returns (BigNumber memory) {
+    function totalSupply() internal returns (BigInt memory) {
         bytes memory raw_request = new bytes(0);
 
         bytes memory raw_response = Actor.call(DataCapTypes.TotalSupplyMethodNum, DataCapTypes.ActorCode, raw_request, Misc.NONE_CODEC);
@@ -72,7 +72,7 @@ library DataCapAPI {
         return result.deserializeBigNum();
     }
 
-    function balance(bytes memory addr) internal returns (BigNumber memory) {
+    function balance(bytes memory addr) internal returns (BigInt memory) {
         bytes memory raw_request = addr.serializeAddress();
 
         bytes memory raw_response = Actor.call(DataCapTypes.BalanceOfMethodNum, DataCapTypes.ActorCode, raw_request, Misc.CBOR_CODEC);
@@ -82,7 +82,7 @@ library DataCapAPI {
         return result.deserializeBigNum();
     }
 
-    function allowance(DataCapTypes.GetAllowanceParams memory params) internal returns (BigNumber memory) {
+    function allowance(DataCapTypes.GetAllowanceParams memory params) internal returns (BigInt memory) {
         bytes memory raw_request = params.serialize();
 
         bytes memory raw_response = Actor.call(DataCapTypes.AllowanceMethodNum, DataCapTypes.ActorCode, raw_request, Misc.CBOR_CODEC);
@@ -118,7 +118,7 @@ library DataCapAPI {
         return response;
     }
 
-    function increaseAllowance(DataCapTypes.IncreaseAllowanceParams memory params) internal returns (BigNumber memory) {
+    function increaseAllowance(DataCapTypes.IncreaseAllowanceParams memory params) internal returns (BigInt memory) {
         bytes memory raw_request = params.serialize();
 
         bytes memory raw_response = Actor.call(
@@ -133,7 +133,7 @@ library DataCapAPI {
         return result.deserializeBigNum();
     }
 
-    function decreaseAllowance(DataCapTypes.DecreaseAllowanceParams memory params) internal returns (BigNumber memory) {
+    function decreaseAllowance(DataCapTypes.DecreaseAllowanceParams memory params) internal returns (BigInt memory) {
         bytes memory raw_request = params.serialize();
 
         bytes memory raw_response = Actor.call(
@@ -148,7 +148,7 @@ library DataCapAPI {
         return result.deserializeBigNum();
     }
 
-    function revokeAllowance(DataCapTypes.RevokeAllowanceParams memory params) internal returns (BigNumber memory) {
+    function revokeAllowance(DataCapTypes.RevokeAllowanceParams memory params) internal returns (BigInt memory) {
         bytes memory raw_request = params.serialize();
 
         bytes memory raw_response = Actor.call(DataCapTypes.RevokeAllowanceMethodNum, DataCapTypes.ActorCode, raw_request, Misc.CBOR_CODEC);

--- a/contracts/v0.8/cbor/BigIntCbor.sol
+++ b/contracts/v0.8/cbor/BigIntCbor.sol
@@ -19,13 +19,13 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.4.25 <=0.8.17;
 
-struct BigNumber {
+struct BigInt {
     bytes val;
     bool neg;
 }
 
-library BigNumberCBOR {
-    function serializeBigNum(BigNumber memory num) internal pure returns (bytes memory) {
+library BigIntCBOR {
+    function serializeBigNum(BigInt memory num) internal pure returns (bytes memory) {
         // TODO improve gas efficiency by using assembly code
         bytes memory raw = new bytes(num.val.length + 1);
 
@@ -42,7 +42,7 @@ library BigNumberCBOR {
         return raw;
     }
 
-    function deserializeBigNum(bytes memory raw) internal pure returns (BigNumber memory) {
+    function deserializeBigNum(bytes memory raw) internal pure returns (BigInt memory) {
         // TODO improve gas efficiency by using assembly code
         bytes memory val = new bytes(raw.length - 1);
         bool neg = false;
@@ -55,6 +55,6 @@ library BigNumberCBOR {
             val[i - 1] = raw[i];
         }
 
-        return BigNumber(val, neg);
+        return BigInt(val, neg);
     }
 }

--- a/contracts/v0.8/cbor/DataCapCbor.sol
+++ b/contracts/v0.8/cbor/DataCapCbor.sol
@@ -25,12 +25,12 @@ import {CommonTypes} from "../types/CommonTypes.sol";
 import {DataCapTypes} from "../types/DataCapTypes.sol";
 import "../utils/CborDecode.sol";
 import "../utils/Misc.sol";
-import "./BigNumberCbor.sol";
+import "./BigIntCbor.sol";
 
 library BytesCBOR {
     using CBOR for CBOR.CBORBuffer;
     using CBORDecoder for bytes;
-    using BigNumberCBOR for bytes;
+    using BigIntCBOR for bytes;
 
     function serializeAddress(bytes memory addr) internal pure returns (bytes memory) {
         // FIXME what should the max length be on the buffer?
@@ -68,7 +68,7 @@ library BytesCBOR {
         return response;
     }
 
-    function deserializeBigNum(bytes memory ret) internal pure returns (BigNumber memory) {
+    function deserializeBigNum(bytes memory ret) internal pure returns (BigInt memory) {
         bytes memory tmp;
         uint byteIdx = 0;
 
@@ -79,7 +79,7 @@ library BytesCBOR {
             }
         }
 
-        return BigNumber(new bytes(0), false);
+        return BigInt(new bytes(0), false);
     }
 }
 
@@ -106,8 +106,8 @@ library GetAllowanceCBOR {
 library TransferCBOR {
     using CBOR for CBOR.CBORBuffer;
     using CBORDecoder for bytes;
-    using BigNumberCBOR for BigNumber;
-    using BigNumberCBOR for bytes;
+    using BigIntCBOR for BigInt;
+    using BigIntCBOR for bytes;
 
     function serialize(DataCapTypes.TransferParams memory params) internal pure returns (bytes memory) {
         // FIXME what should the max length be on the buffer?
@@ -144,8 +144,8 @@ library TransferCBOR {
 library TransferFromCBOR {
     using CBOR for CBOR.CBORBuffer;
     using CBORDecoder for bytes;
-    using BigNumberCBOR for BigNumber;
-    using BigNumberCBOR for bytes;
+    using BigIntCBOR for BigInt;
+    using BigIntCBOR for bytes;
 
     function serialize(DataCapTypes.TransferFromParams memory params) internal pure returns (bytes memory) {
         // FIXME what should the max length be on the buffer?
@@ -186,7 +186,7 @@ library TransferFromCBOR {
 library IncreaseAllowanceCBOR {
     using CBOR for CBOR.CBORBuffer;
     using CBORDecoder for bytes;
-    using BigNumberCBOR for BigNumber;
+    using BigIntCBOR for BigInt;
 
     function serialize(DataCapTypes.IncreaseAllowanceParams memory params) internal pure returns (bytes memory) {
         // FIXME what should the max length be on the buffer?
@@ -205,7 +205,7 @@ library IncreaseAllowanceCBOR {
 library DecreaseAllowanceCBOR {
     using CBOR for CBOR.CBORBuffer;
     using CBORDecoder for bytes;
-    using BigNumberCBOR for BigNumber;
+    using BigIntCBOR for BigInt;
 
     function serialize(DataCapTypes.DecreaseAllowanceParams memory params) internal pure returns (bytes memory) {
         // FIXME what should the max length be on the buffer?
@@ -241,8 +241,8 @@ library RevokeAllowanceCBOR {
 library BurnCBOR {
     using CBOR for CBOR.CBORBuffer;
     using CBORDecoder for bytes;
-    using BigNumberCBOR for BigNumber;
-    using BigNumberCBOR for bytes;
+    using BigIntCBOR for BigInt;
+    using BigIntCBOR for bytes;
 
     function serialize(DataCapTypes.BurnParams memory params) internal pure returns (bytes memory) {
         // FIXME what should the max length be on the buffer?
@@ -272,8 +272,8 @@ library BurnCBOR {
 library BurnFromCBOR {
     using CBOR for CBOR.CBORBuffer;
     using CBORDecoder for bytes;
-    using BigNumberCBOR for BigNumber;
-    using BigNumberCBOR for bytes;
+    using BigIntCBOR for BigInt;
+    using BigIntCBOR for bytes;
 
     function serialize(DataCapTypes.BurnFromParams memory params) internal pure returns (bytes memory) {
         // FIXME what should the max length be on the buffer?

--- a/contracts/v0.8/cbor/MarketCbor.sol
+++ b/contracts/v0.8/cbor/MarketCbor.sol
@@ -22,7 +22,7 @@ pragma solidity >=0.4.25 <=0.8.17;
 import "solidity-cborutils/contracts/CBOR.sol";
 
 import {MarketTypes} from "../types/MarketTypes.sol";
-import "./BigNumberCbor.sol";
+import "./BigIntCbor.sol";
 import "../utils/CborDecode.sol";
 import "../utils/Misc.sol";
 
@@ -31,8 +31,8 @@ import "../utils/Misc.sol";
 library WithdrawBalanceCBOR {
     using CBOR for CBOR.CBORBuffer;
     using CBORDecoder for bytes;
-    using BigNumberCBOR for BigNumber;
-    using BigNumberCBOR for bytes;
+    using BigIntCBOR for BigInt;
+    using BigIntCBOR for bytes;
 
     function serialize(MarketTypes.WithdrawBalanceParams memory params) internal pure returns (bytes memory) {
         // FIXME what should the max length be on the buffer?
@@ -79,7 +79,7 @@ library AddressCBOR {
 
 library GetBalanceCBOR {
     using CBORDecoder for bytes;
-    using BigNumberCBOR for bytes;
+    using BigIntCBOR for bytes;
 
     function deserialize(MarketTypes.GetBalanceReturn memory ret, bytes memory rawResp) internal pure {
         uint byteIdx = 0;
@@ -219,7 +219,7 @@ library GetDealTermCBOR {
 library GetDealEpochPriceCBOR {
     using CBOR for CBOR.CBORBuffer;
     using CBORDecoder for bytes;
-    using BigNumberCBOR for bytes;
+    using BigIntCBOR for bytes;
 
     function serialize(MarketTypes.GetDealEpochPriceParams memory params) internal pure returns (bytes memory) {
         // FIXME what should the max length be on the buffer?
@@ -242,7 +242,7 @@ library GetDealEpochPriceCBOR {
 library GetDealClientCollateralCBOR {
     using CBOR for CBOR.CBORBuffer;
     using CBORDecoder for bytes;
-    using BigNumberCBOR for bytes;
+    using BigIntCBOR for bytes;
 
     function serialize(MarketTypes.GetDealClientCollateralParams memory params) internal pure returns (bytes memory) {
         // FIXME what should the max length be on the buffer?
@@ -265,7 +265,7 @@ library GetDealClientCollateralCBOR {
 library GetDealProviderCollateralCBOR {
     using CBOR for CBOR.CBORBuffer;
     using CBORDecoder for bytes;
-    using BigNumberCBOR for bytes;
+    using BigIntCBOR for bytes;
 
     function serialize(MarketTypes.GetDealProviderCollateralParams memory params) internal pure returns (bytes memory) {
         // FIXME what should the max length be on the buffer?
@@ -341,7 +341,7 @@ library GetDealActivationCBOR {
 library PublishStorageDealsCBOR {
     using CBOR for CBOR.CBORBuffer;
     using CBORDecoder for bytes;
-    using BigNumberCBOR for BigNumber;
+    using BigIntCBOR for BigInt;
 
     function serialize(MarketTypes.PublishStorageDealsParams memory params) internal pure returns (bytes memory) {
         // FIXME what should the max length be on the buffer?

--- a/contracts/v0.8/cbor/MinerCbor.sol
+++ b/contracts/v0.8/cbor/MinerCbor.sol
@@ -25,14 +25,14 @@ import {CommonTypes} from "../types/CommonTypes.sol";
 import {MinerTypes} from "../types/MinerTypes.sol";
 import "../utils/CborDecode.sol";
 import "../utils/Misc.sol";
-import "./BigNumberCbor.sol";
+import "./BigIntCbor.sol";
 
 /// @title FIXME
 /// @author Zondax AG
 library ChangeBeneficiaryCBOR {
     using CBOR for CBOR.CBORBuffer;
     using CBORDecoder for bytes;
-    using BigNumberCBOR for BigNumber;
+    using BigIntCBOR for BigInt;
 
     function serialize(MinerTypes.ChangeBeneficiaryParams memory params) internal pure returns (bytes memory) {
         // FIXME what should the max length be on the buffer?
@@ -91,7 +91,7 @@ library GetSectorSizeCBOR {
 library GetAvailableBalanceCBOR {
     using CBOR for CBOR.CBORBuffer;
     using CBORDecoder for bytes;
-    using BigNumberCBOR for bytes;
+    using BigIntCBOR for bytes;
 
     function deserialize(MinerTypes.GetAvailableBalanceReturn memory ret, bytes memory rawResp) internal pure {
         uint byteIdx = 0;
@@ -101,7 +101,7 @@ library GetAvailableBalanceCBOR {
         if (tmp.length > 0) {
             ret.available_balance = tmp.deserializeBigNum();
         } else {
-            ret.available_balance = BigNumber(new bytes(0), false);
+            ret.available_balance = BigInt(new bytes(0), false);
         }
     }
 }
@@ -132,7 +132,7 @@ library AddressCBOR {
 library GetBeneficiaryCBOR {
     using CBOR for CBOR.CBORBuffer;
     using CBORDecoder for bytes;
-    using BigNumberCBOR for bytes;
+    using BigIntCBOR for bytes;
 
     function deserialize(MinerTypes.GetBeneficiaryReturn memory ret, bytes memory rawResp) internal pure {
         bytes memory tmp;
@@ -154,14 +154,14 @@ library GetBeneficiaryCBOR {
         if (tmp.length > 0) {
             ret.active.term.quota = tmp.deserializeBigNum();
         } else {
-            ret.active.term.quota = BigNumber(new bytes(0), false);
+            ret.active.term.quota = BigInt(new bytes(0), false);
         }
 
         (tmp, byteIdx) = rawResp.readBytes(byteIdx);
         if (tmp.length > 0) {
             ret.active.term.used_quota = tmp.deserializeBigNum();
         } else {
-            ret.active.term.used_quota = BigNumber(new bytes(0), false);
+            ret.active.term.used_quota = BigInt(new bytes(0), false);
         }
 
         (ret.active.term.expiration, byteIdx) = rawResp.readUInt64(byteIdx);
@@ -176,7 +176,7 @@ library GetBeneficiaryCBOR {
             if (tmp.length > 0) {
                 ret.proposed.new_quota = tmp.deserializeBigNum();
             } else {
-                ret.proposed.new_quota = BigNumber(new bytes(0), false);
+                ret.proposed.new_quota = BigInt(new bytes(0), false);
             }
 
             (ret.proposed.new_expiration, byteIdx) = rawResp.readUInt64(byteIdx);
@@ -189,11 +189,11 @@ library GetBeneficiaryCBOR {
 library GetVestingFundsCBOR {
     using CBOR for CBOR.CBORBuffer;
     using CBORDecoder for bytes;
-    using BigNumberCBOR for bytes;
+    using BigIntCBOR for bytes;
 
     function deserialize(MinerTypes.GetVestingFundsReturn memory ret, bytes memory rawResp) internal pure {
         int64 epoch;
-        BigNumber memory amount;
+        BigInt memory amount;
         bytes memory tmp;
 
         uint byteIdx = 0;

--- a/contracts/v0.8/cbor/MultisigCbor.sol
+++ b/contracts/v0.8/cbor/MultisigCbor.sol
@@ -24,7 +24,7 @@ import "solidity-cborutils/contracts/CBOR.sol";
 import {MultisigTypes} from "../types/MultisigTypes.sol";
 import "../utils/CborDecode.sol";
 import "../utils/Misc.sol";
-import "./BigNumberCbor.sol";
+import "./BigIntCbor.sol";
 
 library BytesCBOR {
     using CBOR for CBOR.CBORBuffer;
@@ -45,7 +45,7 @@ library BytesCBOR {
 library ProposeCBOR {
     using CBOR for CBOR.CBORBuffer;
     using CBORDecoder for bytes;
-    using BigNumberCBOR for BigNumber;
+    using BigIntCBOR for BigInt;
 
     function serialize(MultisigTypes.ProposeParams memory params) internal pure returns (bytes memory) {
         // FIXME what should the max length be on the buffer?
@@ -187,7 +187,7 @@ library ChangeNumApprovalsThresholdCBOR {
 library LockBalanceCBOR {
     using CBOR for CBOR.CBORBuffer;
     using CBORDecoder for bytes;
-    using BigNumberCBOR for BigNumber;
+    using BigIntCBOR for BigInt;
 
     function serialize(MultisigTypes.LockBalanceParams memory params) internal pure returns (bytes memory) {
         // FIXME what should the max length be on the buffer?

--- a/contracts/v0.8/cbor/PowerCbor.sol
+++ b/contracts/v0.8/cbor/PowerCbor.sol
@@ -25,7 +25,7 @@ import {CommonTypes} from "../types/CommonTypes.sol";
 import {PowerTypes} from "../types/PowerTypes.sol";
 import "../utils/CborDecode.sol";
 import "../utils/Misc.sol";
-import "./BigNumberCbor.sol";
+import "./BigIntCbor.sol";
 
 /// @title FIXME
 /// @author Zondax AG
@@ -96,7 +96,7 @@ library MinerConsensusCountCBOR {
 library NetworkRawPowerCBOR {
     using CBOR for CBOR.CBORBuffer;
     using CBORDecoder for bytes;
-    using BigNumberCBOR for bytes;
+    using BigIntCBOR for bytes;
 
     function deserialize(PowerTypes.NetworkRawPowerReturn memory ret, bytes memory rawResp) internal pure {
         uint byteIdx = 0;
@@ -106,7 +106,7 @@ library NetworkRawPowerCBOR {
         if (tmp.length > 0) {
             ret.raw_byte_power = tmp.deserializeBigNum();
         } else {
-            ret.raw_byte_power = BigNumber(new bytes(0), false);
+            ret.raw_byte_power = BigInt(new bytes(0), false);
         }
     }
 }
@@ -116,7 +116,7 @@ library NetworkRawPowerCBOR {
 library MinerRawPowerCBOR {
     using CBOR for CBOR.CBORBuffer;
     using CBORDecoder for bytes;
-    using BigNumberCBOR for bytes;
+    using BigIntCBOR for bytes;
 
     function serialize(PowerTypes.MinerRawPowerParams memory params) internal pure returns (bytes memory) {
         // FIXME what should the max length be on the buffer?
@@ -139,7 +139,7 @@ library MinerRawPowerCBOR {
         if (tmp.length > 0) {
             ret.raw_byte_power = tmp.deserializeBigNum();
         } else {
-            ret.raw_byte_power = BigNumber(new bytes(0), false);
+            ret.raw_byte_power = BigInt(new bytes(0), false);
         }
 
         (ret.meets_consensus_minimum, byteIdx) = rawResp.readBool(byteIdx);

--- a/contracts/v0.8/cbor/VerifRegCbor.sol
+++ b/contracts/v0.8/cbor/VerifRegCbor.sol
@@ -25,7 +25,7 @@ import {CommonTypes} from "../types/CommonTypes.sol";
 import {VerifRegTypes} from "../types/VerifRegTypes.sol";
 import "../utils/CborDecode.sol";
 import "../utils/Misc.sol";
-import "./BigNumberCbor.sol";
+import "./BigIntCbor.sol";
 
 /// @title FIXME
 /// @author Zondax AG
@@ -112,7 +112,7 @@ library AddVerifierClientCBOR {
 library RemoveExpiredAllocationsCBOR {
     using CBOR for CBOR.CBORBuffer;
     using CBORDecoder for bytes;
-    using BigNumberCBOR for bytes;
+    using BigIntCBOR for bytes;
 
     function serialize(VerifRegTypes.RemoveExpiredAllocationsParams memory params) internal pure returns (bytes memory) {
         // FIXME what should the max length be on the buffer?

--- a/contracts/v0.8/mocks/MarketAPI.sol
+++ b/contracts/v0.8/mocks/MarketAPI.sol
@@ -22,14 +22,14 @@ pragma solidity >=0.4.25 <=0.8.17;
 import "../types/MarketTypes.sol";
 import "./types/MockTypes.sol";
 
-import {BigNumbers, BigNumber as BigNum} from "@zondax/solidity-bignumber/src/BigNumbers.sol";
+import {BigNumbers, BigNumber} from "@zondax/solidity-bignumber/src/BigNumbers.sol";
 
 /// @title This contract is a proxy to the singleton Storage Market actor (address: f05). Calling one of its methods will result in a cross-actor call being performed. However, in this mock library, no actual call is performed.
 /// @author Zondax AG
 /// @dev Methods prefixed with mock_ will not be available in the real library. These methods are merely used to set mock state. Note that this interface will likely break in the future as we align it
 //       with that of the real library!
 contract MarketAPI {
-    mapping(string => BigNum) balances;
+    mapping(string => BigNumber) balances;
     mapping(uint64 => MockTypes.Deal) deals;
 
     constructor() {
@@ -39,7 +39,7 @@ contract MarketAPI {
     /// @notice Deposits the received value into the balance held in escrow.
     /// @dev Because this is a mock method, no real balance is being deducted from the caller, nor incremented in the Storage Market actor (f05).
     function add_balance(bytes memory provider_or_client) public payable {
-        BigNum memory newValue = BigNumbers.init(msg.value, false);
+        BigNumber memory newValue = BigNumbers.init(msg.value, false);
         balances[string(provider_or_client)] = BigNumbers.add(balances[string(provider_or_client)], newValue);
     }
 
@@ -48,8 +48,8 @@ contract MarketAPI {
     /// @dev This method should be called by an approved address, but the mock does not check that the caller is an approved party.
     /// @dev Because this is a mock method, no real balance is deposited in the designated address, nor decremented from the Storage Market actor (f05).
     function withdraw_balance(MarketTypes.WithdrawBalanceParams memory params) public returns (MarketTypes.WithdrawBalanceReturn memory) {
-        BigNum memory balance = balances[string(params.provider_or_client)];
-        BigNum memory tokenAmount = BigNumbers.init(params.tokenAmount.val, params.tokenAmount.neg);
+        BigNumber memory balance = balances[string(params.provider_or_client)];
+        BigNumber memory tokenAmount = BigNumbers.init(params.tokenAmount.val, params.tokenAmount.neg);
 
         if (BigNumbers.gte(balance, tokenAmount)) {
             balances[string(params.provider_or_client)] = BigNumbers.sub(balance, tokenAmount);
@@ -58,15 +58,15 @@ contract MarketAPI {
             balances[string(params.provider_or_client)] = BigNumbers.zero();
         }
 
-        return MarketTypes.WithdrawBalanceReturn(BigNumber(balance.val, balance.neg));
+        return MarketTypes.WithdrawBalanceReturn(BigInt(balance.val, balance.neg));
     }
 
     /// @return the escrow balance and locked amount for an address.
     function get_balance(string memory addr) public view returns (MarketTypes.GetBalanceReturn memory) {
-        BigNum memory actualBalance = balances[addr];
-        BigNum memory zero = BigNumbers.zero();
+        BigNumber memory actualBalance = balances[addr];
+        BigNumber memory zero = BigNumbers.zero();
 
-        return MarketTypes.GetBalanceReturn(BigNumber(actualBalance.val, actualBalance.neg), BigNumber(zero.val, zero.neg));
+        return MarketTypes.GetBalanceReturn(BigInt(actualBalance.val, actualBalance.neg), BigInt(zero.val, zero.neg));
     }
 
     /// @return the data commitment and size of a deal proposal.
@@ -116,8 +116,8 @@ contract MarketAPI {
     ) public view returns (MarketTypes.GetDealEpochPriceReturn memory) {
         require(deals[params.id].id > 0);
 
-        BigNum memory price_per_epoch = BigNumbers.init(deals[params.id].price_per_epoch, false);
-        return MarketTypes.GetDealEpochPriceReturn(BigNumber(price_per_epoch.val, price_per_epoch.neg));
+        BigNumber memory price_per_epoch = BigNumbers.init(deals[params.id].price_per_epoch, false);
+        return MarketTypes.GetDealEpochPriceReturn(BigInt(price_per_epoch.val, price_per_epoch.neg));
     }
 
     /// @return the client collateral requirement for a deal proposal.
@@ -126,8 +126,8 @@ contract MarketAPI {
     ) public view returns (MarketTypes.GetDealClientCollateralReturn memory) {
         require(deals[params.id].id > 0);
 
-        BigNum memory client_collateral = BigNumbers.init(deals[params.id].client_collateral, false);
-        return MarketTypes.GetDealClientCollateralReturn(BigNumber(client_collateral.val, client_collateral.neg));
+        BigNumber memory client_collateral = BigNumbers.init(deals[params.id].client_collateral, false);
+        return MarketTypes.GetDealClientCollateralReturn(BigInt(client_collateral.val, client_collateral.neg));
     }
 
     /// @return the provider collateral requirement for a deal proposal.
@@ -136,8 +136,8 @@ contract MarketAPI {
     ) public view returns (MarketTypes.GetDealProviderCollateralReturn memory) {
         require(deals[params.id].id > 0);
 
-        BigNum memory provider_collateral = BigNumbers.init(deals[params.id].provider_collateral, false);
-        return MarketTypes.GetDealProviderCollateralReturn(BigNumber(provider_collateral.val, provider_collateral.neg));
+        BigNumber memory provider_collateral = BigNumbers.init(deals[params.id].provider_collateral, false);
+        return MarketTypes.GetDealProviderCollateralReturn(BigInt(provider_collateral.val, provider_collateral.neg));
     }
 
     /// @return the verified flag for a deal proposal.

--- a/contracts/v0.8/mocks/MinerAPI.sol
+++ b/contracts/v0.8/mocks/MinerAPI.sol
@@ -19,7 +19,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.4.25 <=0.8.17;
 
-import {BigNumbers, BigNumber as BigNum} from "@zondax/solidity-bignumber/src/BigNumbers.sol";
+import {BigNumbers, BigNumber} from "@zondax/solidity-bignumber/src/BigNumbers.sol";
 
 import "../types/MinerTypes.sol";
 
@@ -87,13 +87,13 @@ contract MinerAPI {
     /// @notice Can go negative if the miner is in IP debt.
     /// @return the available balance of this miner.
     function get_available_balance() public pure returns (MinerTypes.GetAvailableBalanceReturn memory) {
-        return MinerTypes.GetAvailableBalanceReturn(BigNumber(hex"021E19E0C9BAB2400000", false));
+        return MinerTypes.GetAvailableBalanceReturn(BigInt(hex"021E19E0C9BAB2400000", false));
     }
 
     /// @return the funds vesting in this miner as a list of (vesting_epoch, vesting_amount) tuples.
     function get_vesting_funds() public pure returns (MinerTypes.GetVestingFundsReturn memory) {
         CommonTypes.VestingFunds[] memory vesting_funds = new CommonTypes.VestingFunds[](1);
-        vesting_funds[0] = CommonTypes.VestingFunds(1668514825, BigNumber(hex"6C6B935B8BBD400000", false));
+        vesting_funds[0] = CommonTypes.VestingFunds(1668514825, BigInt(hex"6C6B935B8BBD400000", false));
 
         return MinerTypes.GetVestingFundsReturn(vesting_funds);
     }
@@ -103,10 +103,10 @@ contract MinerAPI {
     /// @notice See FIP-0029, https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0029.md
     function change_beneficiary(MinerTypes.ChangeBeneficiaryParams memory params) public {
         if (!isBeneficiarySet) {
-            BigNum memory zero = BigNumbers.zero();
+            BigNumber memory zero = BigNumbers.zero();
             CommonTypes.BeneficiaryTerm memory term = CommonTypes.BeneficiaryTerm(
                 params.new_quota,
-                BigNumber(zero.val, zero.neg),
+                BigInt(zero.val, zero.neg),
                 params.new_expiration
             );
             activeBeneficiary = CommonTypes.ActiveBeneficiary(params.new_beneficiary, term);

--- a/contracts/v0.8/tests/datacap.test.sol
+++ b/contracts/v0.8/tests/datacap.test.sol
@@ -20,7 +20,7 @@
 pragma solidity >=0.4.25 <=0.8.17;
 
 import "../types/DataCapTypes.sol";
-import "../cbor/BigNumberCbor.sol";
+import "../cbor/BigIntCbor.sol";
 import "../DataCapAPI.sol";
 
 /// @author Zondax AG
@@ -33,15 +33,15 @@ contract DataCapApiTest {
         return DataCapAPI.symbol();
     }
 
-    function total_supply() public returns (BigNumber memory) {
+    function total_supply() public returns (BigInt memory) {
         return DataCapAPI.totalSupply();
     }
 
-    function balance(bytes memory addr) public returns (BigNumber memory) {
+    function balance(bytes memory addr) public returns (BigInt memory) {
         return DataCapAPI.balance(addr);
     }
 
-    function allowance(DataCapTypes.GetAllowanceParams memory params) public returns (BigNumber memory) {
+    function allowance(DataCapTypes.GetAllowanceParams memory params) public returns (BigInt memory) {
         return DataCapAPI.allowance(params);
     }
 
@@ -53,15 +53,15 @@ contract DataCapApiTest {
         return DataCapAPI.transferFrom(params);
     }
 
-    function increase_allowance(DataCapTypes.IncreaseAllowanceParams memory params) public returns (BigNumber memory) {
+    function increase_allowance(DataCapTypes.IncreaseAllowanceParams memory params) public returns (BigInt memory) {
         return DataCapAPI.increaseAllowance(params);
     }
 
-    function decrease_allowance(DataCapTypes.DecreaseAllowanceParams memory params) public returns (BigNumber memory) {
+    function decrease_allowance(DataCapTypes.DecreaseAllowanceParams memory params) public returns (BigInt memory) {
         return DataCapAPI.decreaseAllowance(params);
     }
 
-    function revoke_allowance(DataCapTypes.RevokeAllowanceParams memory params) public returns (BigNumber memory) {
+    function revoke_allowance(DataCapTypes.RevokeAllowanceParams memory params) public returns (BigInt memory) {
         return DataCapAPI.revokeAllowance(params);
     }
 

--- a/contracts/v0.8/types/CommonTypes.sol
+++ b/contracts/v0.8/types/CommonTypes.sol
@@ -19,7 +19,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.4.25 <=0.8.17;
 
-import "../cbor/BigNumberCbor.sol";
+import "../cbor/BigIntCbor.sol";
 
 /// @title Filecoin actors' common types for Solidity.
 /// @author Zondax AG
@@ -87,15 +87,15 @@ library CommonTypes {
 
     struct PendingBeneficiaryChange {
         bytes new_beneficiary;
-        BigNumber new_quota;
+        BigInt new_quota;
         uint64 new_expiration;
         bool approved_by_beneficiary;
         bool approved_by_nominee;
     }
 
     struct BeneficiaryTerm {
-        BigNumber quota;
-        BigNumber used_quota;
+        BigInt quota;
+        BigInt used_quota;
         uint64 expiration;
     }
 
@@ -206,7 +206,7 @@ library CommonTypes {
 
     struct VestingFunds {
         int64 epoch;
-        BigNumber amount;
+        BigInt amount;
     }
     struct SectorDeals {
         int64 sector_type;
@@ -223,9 +223,9 @@ library CommonTypes {
         string label;
         int64 start_epoch;
         int64 end_epoch;
-        BigNumber storage_price_per_epoch;
-        BigNumber provider_collateral;
-        BigNumber client_collateral;
+        BigInt storage_price_per_epoch;
+        BigInt provider_collateral;
+        BigInt client_collateral;
     }
 
     struct ClientDealProposal {

--- a/contracts/v0.8/types/DataCapTypes.sol
+++ b/contracts/v0.8/types/DataCapTypes.sol
@@ -19,7 +19,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.4.25 <=0.8.17;
 
-import "../cbor/BigNumberCbor.sol";
+import "../cbor/BigIntCbor.sol";
 
 /// @title Filecoin datacap actor types for Solidity.
 /// @author Zondax AG
@@ -47,15 +47,15 @@ library DataCapTypes {
     struct TransferParams {
         bytes to;
         /// A non-negative amount to transfer
-        BigNumber amount;
+        BigInt amount;
         /// Arbitrary data to pass on via the receiver hook
         bytes operator_data;
     }
 
     struct TransferReturn {
-        BigNumber from_balance;
+        BigInt from_balance;
         /// The new balance of the `to` address
-        BigNumber to_balance;
+        BigInt to_balance;
         /// (Optional) data returned from receiver hook
         bytes recipient_data;
     }
@@ -64,17 +64,17 @@ library DataCapTypes {
         bytes from;
         bytes to;
         /// A non-negative amount to transfer
-        BigNumber amount;
+        BigInt amount;
         /// Arbitrary data to pass on via the receiver hook
         bytes operator_data;
     }
 
     struct TransferFromReturn {
-        BigNumber from_balance;
+        BigInt from_balance;
         /// The new balance of the `to` address
-        BigNumber to_balance;
+        BigInt to_balance;
         /// The new remaining allowance between `owner` and `operator` (caller)
-        BigNumber allowance;
+        BigInt allowance;
         /// (Optional) data returned from receiver hook
         bytes recipient_data;
     }
@@ -82,12 +82,12 @@ library DataCapTypes {
     struct IncreaseAllowanceParams {
         bytes operator;
         /// A non-negative amount to increase the allowance by
-        BigNumber increase;
+        BigInt increase;
     }
     struct DecreaseAllowanceParams {
         bytes operator;
         /// A non-negative amount to decrease the allowance by
-        BigNumber decrease;
+        BigInt decrease;
     }
     struct RevokeAllowanceParams {
         bytes operator;
@@ -95,24 +95,24 @@ library DataCapTypes {
 
     struct BurnParams {
         /// A non-negative amount to burn
-        BigNumber amount;
+        BigInt amount;
     }
 
     struct BurnReturn {
         /// New balance in the account after the successful burn
-        BigNumber balance;
+        BigInt balance;
     }
 
     struct BurnFromParams {
         bytes owner;
         /// A non-negative amount to burn
-        BigNumber amount;
+        BigInt amount;
     }
 
     struct BurnFromReturn {
         /// New balance in the account after the successful burn
-        BigNumber balance;
+        BigInt balance;
         /// New remaining allowance between the owner and operator (caller)
-        BigNumber allowance;
+        BigInt allowance;
     }
 }

--- a/contracts/v0.8/types/MarketTypes.sol
+++ b/contracts/v0.8/types/MarketTypes.sol
@@ -19,7 +19,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.4.25 <=0.8.17;
 
-import "../cbor/BigNumberCbor.sol";
+import "../cbor/BigIntCbor.sol";
 import "./CommonTypes.sol";
 
 /// @title Filecoin market actor types for Solidity.
@@ -43,16 +43,16 @@ library MarketTypes {
 
     struct WithdrawBalanceParams {
         bytes provider_or_client;
-        BigNumber tokenAmount;
+        BigInt tokenAmount;
     }
 
     struct WithdrawBalanceReturn {
-        BigNumber amount_withdrawn;
+        BigInt amount_withdrawn;
     }
 
     struct GetBalanceReturn {
-        BigNumber balance;
-        BigNumber locked;
+        BigInt balance;
+        BigInt locked;
     }
 
     struct GetDealDataCommitmentParams {
@@ -102,7 +102,7 @@ library MarketTypes {
     }
 
     struct GetDealEpochPriceReturn {
-        BigNumber price_per_epoch;
+        BigInt price_per_epoch;
     }
 
     struct GetDealClientCollateralParams {
@@ -110,7 +110,7 @@ library MarketTypes {
     }
 
     struct GetDealClientCollateralReturn {
-        BigNumber collateral;
+        BigInt collateral;
     }
 
     struct GetDealProviderCollateralParams {
@@ -118,7 +118,7 @@ library MarketTypes {
     }
 
     struct GetDealProviderCollateralReturn {
-        BigNumber collateral;
+        BigInt collateral;
     }
 
     struct GetDealVerifiedParams {

--- a/contracts/v0.8/types/MinerTypes.sol
+++ b/contracts/v0.8/types/MinerTypes.sol
@@ -19,7 +19,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.4.25 <=0.8.17;
 
-import "../cbor/BigNumberCbor.sol";
+import "../cbor/BigIntCbor.sol";
 import "./CommonTypes.sol";
 
 /// @title Filecoin miner actor types for Solidity.
@@ -59,7 +59,7 @@ library MinerTypes {
         uint64 sector_size;
     }
     struct GetAvailableBalanceReturn {
-        BigNumber available_balance;
+        BigInt available_balance;
     }
 
     struct GetVestingFundsReturn {
@@ -68,7 +68,7 @@ library MinerTypes {
 
     struct ChangeBeneficiaryParams {
         bytes new_beneficiary;
-        BigNumber new_quota;
+        BigInt new_quota;
         uint64 new_expiration;
     }
 

--- a/contracts/v0.8/types/MultisigTypes.sol
+++ b/contracts/v0.8/types/MultisigTypes.sol
@@ -19,7 +19,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.4.25 <=0.8.17;
 
-import "../cbor/BigNumberCbor.sol";
+import "../cbor/BigIntCbor.sol";
 import "./CommonTypes.sol";
 
 /// @title Filecoin multisig actor types for Solidity.
@@ -37,7 +37,7 @@ library MultisigTypes {
 
     struct ProposeParams {
         bytes to;
-        BigNumber value;
+        BigInt value;
         uint64 method;
         bytes params;
     }
@@ -95,6 +95,6 @@ library MultisigTypes {
     struct LockBalanceParams {
         int64 start_epoch;
         int64 unlock_duration;
-        BigNumber amount;
+        BigInt amount;
     }
 }

--- a/contracts/v0.8/types/PowerTypes.sol
+++ b/contracts/v0.8/types/PowerTypes.sol
@@ -19,7 +19,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.4.25 <=0.8.17;
 
-import "../cbor/BigNumberCbor.sol";
+import "../cbor/BigIntCbor.sol";
 import "./CommonTypes.sol";
 
 /// @title Filecoin power actor types for Solidity.
@@ -52,13 +52,13 @@ library PowerTypes {
         int64 miner_consensus_count;
     }
     struct NetworkRawPowerReturn {
-        BigNumber raw_byte_power;
+        BigInt raw_byte_power;
     }
     struct MinerRawPowerParams {
         uint64 miner;
     }
     struct MinerRawPowerReturn {
-        BigNumber raw_byte_power;
+        BigInt raw_byte_power;
         bool meets_consensus_minimum;
     }
 }

--- a/contracts/v0.8/types/VerifRegTypes.sol
+++ b/contracts/v0.8/types/VerifRegTypes.sol
@@ -19,7 +19,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.4.25 <=0.8.17;
 
-import "../cbor/BigNumberCbor.sol";
+import "../cbor/BigIntCbor.sol";
 import "./CommonTypes.sol";
 
 /// @title Filecoin Verified Registry actor types for Solidity.
@@ -58,7 +58,7 @@ library VerifRegTypes {
         // Results for each processed allocation.
         CommonTypes.BatchReturn results;
         // The amount of datacap reclaimed for the client.
-        BigNumber datacap_recovered;
+        BigInt datacap_recovered;
     }
     struct RemoveExpiredClaimsParams {
         // Provider to clean up (need not be the caller)

--- a/docs/api/use-it.md
+++ b/docs/api/use-it.md
@@ -3,14 +3,10 @@ title: How to use it on my project?
 sidebar_position: 2
 ---
 
-In order to use these APIs in your project, you will need to deploy them first. As they are contracts themselves, they need to be present on the chain first. Then, using the address you get from deploying them,
-you can reference them on your project. 
+In order to use these APIs in your project, you will need to import them on your own contract. 
+As they are embeddable libraries, they don't need to be present on the chain first. You can just import the library you desire and call its methods.
 
 ## Steps
-
-### Deploy API
-
-In order to deploy these libraries, please refer to [this section](../deploy-it.md). You will find useful information about it. 
 
 ### Import API contract on your project 
 
@@ -36,22 +32,58 @@ In your smart contract, copy and paste these lines.
 import { MarketAPI } from "@zondax/filecoin-solidity/contracts/v0.8/MarketAPI.sol";
 import { CommonTypes } from "@zondax/filecoin-solidity/contracts/v0.8/types/CommonTypes.sol";
 import { MarketTypes } from "@zondax/filecoin-solidity/contracts/v0.8/types/MarketAPI.sol";
-```
-
-
-### Create a callable instance 
-```solidity
-MarketAPI marketApiInstance = MarketAPI(marketApiAddress);
+import { BigInt } from "@zondax/filecoin-solidity/contracts/v0.8/cbor/BigNumberCbor.sol";
 ```
 
 ### Do a call to a particular method
 
 ```solidity
 bytes memory addr = bytes("0x1111");
-MarketTypes.WithdrawBalanceParams memory params = MarketTypes.WithdrawBalanceParams(addr, 1);
+BigInt memory amount = BigInt(hex'01', false);
 
-MarketTypes.WithdrawBalanceReturn memory response = marketApiInstance.withdraw_balance(params);
+MarketTypes.WithdrawBalanceParams memory params = MarketTypes.WithdrawBalanceParams(addr, amount);
+
+MarketTypes.WithdrawBalanceReturn memory response = MarketAPI.withdrawBalance(params);
 ```
+
+### Deploy your contract
+
+In order to deploy your project, please refer to [this section](../deploy-it.md). You will find useful information about it.
+
+### Apendix A: BigNumber
+There are certain fields that are BigInt. This is a particular data type meant to handle arbitrary-length numbers. They are composed by a byte array and a flag for the sign.
+In order to do operations between elements of this specific type, there is a package you can use, called `@zondax/solidity-bignumber` [:link:](https://github.com/Zondax/solidity-BigNumber).
+Using the NPM package you can add it as a dependency in your project.
+
+```yarn
+yarn add @zondax/solidity-bignumber
+```
+
+Then you can import it on your contract and use it. 
+
+```solidity
+import { BigNumbers, BigNumber } from "@zondax/solidity-bignumber/src/BigNumbers.sol";
+
+BigNumber memory numA = BigNumbers.init(10000, false);
+BigNumber memory numB = BigNumbers.init(2000, false);
+BigNumber result = BigNumbers.add(numA, numB);
+```
+
+Finally, if you need to use it to interact with the APIs, you can convert it to the BigInt type they use easily. 
+
+```solidity
+import { BigNumbers, BigNumber } from "@zondax/solidity-bignumber/src/BigNumbers.sol";
+import { BigInt } from "@zondax/filecoin-solidity/contracts/v0.8/cbor/BigNumberCbor.sol";
+
+BigNumber memory numA = BigNumbers.init(10000, false);
+BigNumber memory numB = BigNumbers.init(2000, false);
+BigNumber result = BigNumbers.add(numA, numB);
+
+BigInt memory amount = BigInt(result.val, result.sig);
+
+// use amount var as arguments for any api method
+```
+
 
 ## Working examples
 In order to see a complete demo you can use as example, please refer to [tests folder](https://github.com/Zondax/filecoin-solidity/tree/master/contracts/v0.8/tests). You will find some smart contracts as examples


### PR DESCRIPTION
- update docs to reflect latest changes
- rename BigNumber struct to BigInt in order to avoid name conflicts with the BigNumbers package

closes #124 