### PR TITLE
Compiler issue when compiling Actor.sol Return type not supported

### DIFF
--- a/contracts/v0.8/utils/Actor.sol
+++ b/contracts/v0.8/utils/Actor.sol
@@ -33,7 +33,7 @@ library Actor {
     uint64 constant DEFAULT_FLAG = 0x00000000;
 
     function call(
-        uint method_num,
+        uint256 method_num,
         bytes memory actor_address,
         bytes memory raw_request,
         uint64 codec,
@@ -49,7 +49,7 @@ library Actor {
 
     function callByID(
         uint64 actor_id,
-        uint method_num,
+        uint256 method_num,
         uint64 codec,
         bytes memory raw_request,
         uint256 amount
@@ -74,7 +74,7 @@ library Actor {
     function getErrorCodeMsg(int256 exit_code) internal pure returns (string memory) {
         return
             exit_code >= 0
-                ? string.concat("actor error code ", Strings.toString(uint256(exit_code)))
-                : string.concat("actor error code -", Strings.toString(Misc.abs(exit_code)));
+                ? string(abi.encodePacked("actor error code ", Strings.toString(uint256(exit_code))))
+                : string(abi.encodePacked("actor error code -", Strings.toString(Misc.abs(exit_code))));
     }
 }


### PR DESCRIPTION
Modified the getErrorCodeMsg function.
* Removed if condition because it returns the same outside the condition too.
* Used abi.encodePacked() to concat string instead of string.concat (for low gas consumption).

The screenshot of the error:
![image](https://user-images.githubusercontent.com/36038687/214522468-cf76f4a3-5505-4b3d-a069-3a43e488a9b4.png)


<!-- ClickUpRef: 86777y94q -->
:link: [zboto Link](https://app.clickup.com/t/86777y94q)